### PR TITLE
#85 - Drop and Drop Documents

### DIFF
--- a/SQL Scripts/functions/update_project_documents_sort_rpc.sql
+++ b/SQL Scripts/functions/update_project_documents_sort_rpc.sql
@@ -1,0 +1,31 @@
+CREATE
+    OR REPLACE FUNCTION update_project_documents_sort_rpc (
+    _project_id uuid,
+    _document_ids uuid[]
+) RETURNS BOOLEAN AS $body$
+DECLARE
+    current_index INT = 0;
+    _document_id uuid;
+BEGIN
+    -- Check project policy that project documents can be updated by this user
+    IF NOT (check_action_policy_organization(auth.uid(), 'project_documents', 'UPDATE')
+        OR check_action_policy_project(auth.uid(), 'project_documents', 'UPDATE', _project_id))
+    THEN
+        RETURN FALSE;
+    END IF;
+
+    FOREACH _document_id IN ARRAY _document_ids
+    LOOP
+
+        UPDATE public.project_documents pd
+           SET sort = current_index
+         WHERE pd.document_id = _document_id
+           AND pd.project_id = _project_id;
+
+        current_index :=  current_index + 1;
+
+    END LOOP;
+
+    RETURN TRUE;
+END
+$body$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/migrations/20241024105310_add_sort_to_project_documents.sql
+++ b/supabase/migrations/20241024105310_add_sort_to_project_documents.sql
@@ -1,0 +1,33 @@
+alter table "public"."project_documents" add column sort integer default 0;
+
+CREATE
+    OR REPLACE FUNCTION update_project_documents_sort_rpc (
+    _project_id uuid,
+    _document_ids uuid[]
+) RETURNS BOOLEAN AS $body$
+DECLARE
+    _current_index integer = 0;
+    _document_id uuid;
+BEGIN
+    -- Check project policy that project documents can be updated by this user
+    IF NOT (check_action_policy_organization(auth.uid(), 'project_documents', 'UPDATE')
+        OR check_action_policy_project(auth.uid(), 'project_documents', 'UPDATE', _project_id))
+    THEN
+        RETURN FALSE;
+    END IF;
+
+    FOREACH _document_id IN ARRAY _document_ids
+        LOOP
+
+            UPDATE public.project_documents pd
+            SET sort = _current_index
+            WHERE pd.document_id = _document_id
+              AND pd.project_id = _project_id;
+
+            _current_index :=  _current_index + 1;
+
+        END LOOP;
+
+    RETURN TRUE;
+END
+$body$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/migrations/20241024105310_add_sort_to_project_documents.sql
+++ b/supabase/migrations/20241024105310_add_sort_to_project_documents.sql
@@ -20,9 +20,9 @@ BEGIN
         LOOP
 
             UPDATE public.project_documents pd
-            SET sort = _current_index
-            WHERE pd.document_id = _document_id
-              AND pd.project_id = _project_id;
+               SET sort = _current_index
+             WHERE pd.document_id = _document_id
+               AND pd.project_id = _project_id;
 
             _current_index :=  _current_index + 1;
 


### PR DESCRIPTION
This pull request adds a migration to add a `sort` column to the `project_documents` table. It also adds an RPC that will update the `sort` values for all of the `project_documents` record in a `project`.

## Questions
- Is there a better way to handle this without an RPC? It doesn't look like there's CRUD support currently for `project_documents`, so handling it via trigger didn't seem like the best avenue either.
- I don't love the fact that we're sending the whole list of document IDs on update, but I couldn't find a better way to do it and also not have to set the order for every existing document in a migration.