### PR TITLE
#139 - Documents metadata

### DIFF
--- a/supabase/migrations/20241227161239_convert_documents_meta_data.sql
+++ b/supabase/migrations/20241227161239_convert_documents_meta_data.sql
@@ -28,7 +28,8 @@ SELECT documents.id AS document_id,
        )) AS meta
   FROM public.documents
  CROSS JOIN json_each_text(documents.meta_data->'meta') AS x
- WHERE x.value IS NOT NULL
+ WHERE json_typeof(documents.meta_data->'meta') = 'object'
+   AND x.value IS NOT NULL
    AND x.value != ''
  GROUP BY documents.id
 ),


### PR DESCRIPTION
This pull request fixes a bug in the documents metadata conversion migration by updating it to only include `documents` record with objects in the `documents.meta_data->'meta'` attribute.