### PR TITLE
Support for context document ordering

### DIFF
--- a/SQL Scripts/functions/update_context_documents_sort_rpc.sql
+++ b/SQL Scripts/functions/update_context_documents_sort_rpc.sql
@@ -1,0 +1,40 @@
+CREATE
+    OR REPLACE FUNCTION update_context_documents_sort_rpc (
+    _context_id uuid,
+    _document_ids uuid[]
+) RETURNS BOOLEAN AS $body$
+DECLARE
+    current_index INT = 0;
+    _document_id uuid;
+    _project_id uuid;
+BEGIN
+
+    -- Get the project id
+    SELECT INTO _project_id c.project_id FROM public.contexts c WHERE id = _context_id;
+    IF _project_id = NULL
+      THEN
+        RETURN FALSE;
+    END IF;
+
+    -- Check project policy that project documents can be updated by this user
+    IF NOT (check_action_policy_organization(auth.uid(), 'context_documents', 'UPDATE')
+        OR check_action_policy_project(auth.uid(), 'context_documents', 'UPDATE', _project_id))
+    THEN
+        RETURN FALSE;
+    END IF;
+
+    FOREACH _document_id IN ARRAY _document_ids
+    LOOP
+
+        UPDATE public.context_documents cd
+           SET sort = current_index
+         WHERE cd.document_id = _document_id
+           AND cd.context_id = _context_id;
+
+        current_index :=  current_index + 1;
+
+    END LOOP;
+
+    RETURN TRUE;
+END
+$body$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/SQL Scripts/tables/context_documents.sql
+++ b/SQL Scripts/tables/context_documents.sql
@@ -6,9 +6,14 @@ CREATE TABLE context_documents(
     updated_by    uuid REFERENCES public.profiles,
     context_id    uuid REFERENCES public.contexts,
     document_id   uuid REFERENCES public.documents,
-    is_archived   BOOLEAN DEFAULT FALSE
+    is_archived   BOOLEAN DEFAULT FALSE,
+    sort          INT DEFAULT 0
 );
 
 -- Changes 3/7/24 --
 ALTER TABLE public.context_documents
     ADD UNIQUE (context_id, document_id); 
+
+-- Changes 6/9/25 --
+ALTER TABLE public.context_documents
+    ADD COLUMN sort INT DEFAULT 0;

--- a/supabase/migrations/20250609175433_support_context_doc_ordering.sql
+++ b/supabase/migrations/20250609175433_support_context_doc_ordering.sql
@@ -1,0 +1,47 @@
+alter table "public"."context_documents" add column "sort" integer default 0;
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.update_context_documents_sort_rpc(_context_id uuid, _document_ids uuid[])
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+    current_index INT = 0;
+    _document_id uuid;
+    _project_id uuid;
+BEGIN
+
+    -- Get the project id
+    SELECT INTO _project_id c.project_id FROM public.contexts c WHERE id = _context_id;
+    IF _project_id = NULL
+      THEN
+        RETURN FALSE;
+    END IF;
+
+    -- Check project policy that project documents can be updated by this user
+    IF NOT (check_action_policy_organization(auth.uid(), 'context_documents', 'UPDATE')
+        OR check_action_policy_project(auth.uid(), 'context_documents', 'UPDATE', _project_id))
+    THEN
+        RETURN FALSE;
+    END IF;
+
+    FOREACH _document_id IN ARRAY _document_ids
+    LOOP
+
+        UPDATE public.context_documents cd
+           SET sort = current_index
+         WHERE cd.document_id = _document_id
+           AND cd.context_id = _context_id;
+
+        current_index :=  current_index + 1;
+
+    END LOOP;
+
+    RETURN TRUE;
+END
+$function$
+;
+
+


### PR DESCRIPTION
# Summary

Adds support for project admins to set the order of documents in assignments via drag-and-drop.

- Addresses https://github.com/performant-software/cove-recogito/issues/169