### PR TITLE
Add migration to create collection triggers

### DIFF
--- a/SQL Scripts/functions/archive_collection_rpc.sql
+++ b/SQL Scripts/functions/archive_collection_rpc.sql
@@ -1,0 +1,45 @@
+CREATE
+OR REPLACE FUNCTION archive_collection_rpc (
+    _collection_id uuid 
+) RETURNS BOOLEAN AS $body$
+DECLARE
+    _row public.collections % rowtype;
+BEGIN
+    -- Check policy that collections can be updated by this user
+    IF NOT (check_action_policy_organization(auth.uid(), 'collections', 'UPDATE')) 
+    THEN
+        RETURN FALSE;
+    END IF; 
+
+    -- Get the collection
+    SELECT * INTO _row FROM public.collections c WHERE c.id = _collection_id;
+
+    -- If the user is the creator or an Org Admin, attempt to archive the collection and its documents
+    IF _row.created_by = auth.uid() OR is_admin_organization(auth.uid())
+    THEN
+        -- Prevent archiving if any of the documents are used in any project
+        IF EXISTS (
+            SELECT 1 FROM public.documents d
+            JOIN public.project_documents pd ON pd.document_id = d.id
+            WHERE d.collection_id = _collection_id AND pd.is_archived = FALSE
+        ) THEN
+            RETURN FALSE;
+        END IF;
+
+        -- Archive the collection
+        UPDATE public.collections
+        SET is_archived = TRUE
+        WHERE id = _collection_id;
+
+        -- Archive its documents
+        UPDATE public.documents
+        SET is_archived = TRUE
+        WHERE collection_id = _collection_id;
+
+
+        RETURN TRUE;
+    END IF;
+
+    RETURN FALSE;
+END
+$body$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/SQL Scripts/policies/documents.sql
+++ b/SQL Scripts/policies/documents.sql
@@ -47,7 +47,10 @@ UPDATE TO authenticated USING (
             OR created_by = auth.uid ()
             OR is_admin_organization (auth.uid ())
         )
-        AND (collection_id ISNULL)
+        AND (
+            collection_id ISNULL
+            OR is_admin_organization (auth.uid ())
+        )
         AND public.check_action_policy_organization (auth.uid (), 'documents', 'UPDATE')
     )
     OR (
@@ -55,7 +58,10 @@ UPDATE TO authenticated USING (
             is_private = FALSE
             OR created_by = auth.uid ()
         )
-        AND (collection_id ISNULL)
+        AND (
+            collection_id ISNULL
+            OR is_admin_organization (auth.uid ())
+        )
         AND public.check_action_policy_project_from_document (auth.uid (), 'documents', 'UPDATE', id)
     )
 )
@@ -78,7 +84,10 @@ WITH
                 is_private = FALSE
                 OR created_by = auth.uid ()
             )
-            AND (collection_id ISNULL)
+            AND (
+                collection_id ISNULL
+                OR is_admin_organization (auth.uid ())
+            )
             AND public.check_action_policy_project_from_document (auth.uid (), 'documents', 'UPDATE', id)
         )
     );

--- a/supabase/migrations/20250925152203_create_collection_triggers.sql
+++ b/supabase/migrations/20250925152203_create_collection_triggers.sql
@@ -1,0 +1,5 @@
+DROP TRIGGER IF EXISTS "on_collection_created" ON "public"."collections";
+CREATE TRIGGER "on_collection_created" BEFORE INSERT ON "public"."collections" FOR EACH ROW EXECUTE FUNCTION "public"."create_dates_and_user"();
+
+DROP TRIGGER IF EXISTS "on_collection_updated" ON "public"."collections";
+CREATE TRIGGER "on_collection_updated" BEFORE UPDATE ON "public"."collections" FOR EACH ROW EXECUTE FUNCTION "public"."update_dates_and_user"();

--- a/supabase/migrations/20250930194247_update_collection_documents_policy.sql
+++ b/supabase/migrations/20250930194247_update_collection_documents_policy.sql
@@ -1,0 +1,54 @@
+DROP POLICY "Users with correct policies can UPDATE on documents" ON public.documents;
+
+CREATE POLICY "Users with correct policies can UPDATE on documents" ON public.documents FOR
+UPDATE TO authenticated USING (
+    (
+        (
+            is_private = FALSE
+            OR created_by = auth.uid ()
+            OR is_admin_organization (auth.uid ())
+        )
+        AND (
+            collection_id ISNULL
+            OR is_admin_organization (auth.uid ())
+        )
+        AND public.check_action_policy_organization (auth.uid (), 'documents', 'UPDATE')
+    )
+    OR (
+        (
+            is_private = FALSE
+            OR created_by = auth.uid ()
+        )
+        AND (
+            collection_id ISNULL
+            OR is_admin_organization (auth.uid ())
+        )
+        AND public.check_action_policy_project_from_document (auth.uid (), 'documents', 'UPDATE', id)
+    )
+)
+WITH
+    CHECK (
+        (
+            (
+                is_private = FALSE
+                OR created_by = auth.uid ()
+                OR is_admin_organization (auth.uid ())
+            )
+            AND (
+                collection_id ISNULL
+                OR is_admin_organization (auth.uid ())
+            )
+            AND public.check_action_policy_organization (auth.uid (), 'documents', 'UPDATE')
+        )
+        OR (
+            (
+                is_private = FALSE
+                OR created_by = auth.uid ()
+            )
+            AND (
+                collection_id ISNULL
+                OR is_admin_organization (auth.uid ())
+            )
+            AND public.check_action_policy_project_from_document (auth.uid (), 'documents', 'UPDATE', id)
+        )
+    );

--- a/supabase/migrations/20251008174641_archive_collection_rpc.sql
+++ b/supabase/migrations/20251008174641_archive_collection_rpc.sql
@@ -1,0 +1,49 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.archive_collection_rpc(_collection_id uuid)
+ RETURNS boolean 
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+    _row public.collections % rowtype;
+BEGIN
+    -- Check policy that collections can be updated by this user
+    IF NOT (check_action_policy_organization(auth.uid(), 'collections', 'UPDATE')) 
+    THEN
+        RETURN FALSE;
+    END IF; 
+
+    -- Get the collection
+    SELECT * INTO _row FROM public.collections c WHERE c.id = _collection_id;
+
+    -- If the user is the creator or an Org Admin, attempt to archive the collection and its documents
+    IF _row.created_by = auth.uid() OR is_admin_organization(auth.uid())
+    THEN
+        -- Prevent archiving if any of the documents are used in any project
+        IF EXISTS (
+            SELECT 1 FROM public.documents d
+            JOIN public.project_documents pd ON pd.document_id = d.id
+            WHERE d.collection_id = _collection_id AND pd.is_archived = FALSE
+        ) THEN
+            RETURN FALSE;
+        END IF;
+
+        -- Archive the collection
+        UPDATE public.collections
+        SET is_archived = TRUE
+        WHERE id = _collection_id;
+
+        -- Archive its documents
+        UPDATE public.documents
+        SET is_archived = TRUE
+        WHERE collection_id = _collection_id;
+
+
+        RETURN TRUE;
+    END IF;
+
+    RETURN FALSE;
+END
+$function$
+;


### PR DESCRIPTION
### In this PR

- Add migration to create collection triggers that existed already in `/SQL Scripts/triggers` but not in supabase.
- Add migration to allow org admins to update docs in a collection
- Add migration to create RPC for archiving (deleting) a collection