### PR TITLE
COVE editions corpus

### DIFF
--- a/SQL Scripts/tables/documents.sql
+++ b/SQL Scripts/tables/documents.sql
@@ -15,7 +15,9 @@ CREATE TABLE public.documents
     meta_data    json DEFAULT {},
     is_private   BOOLEAN DEFAULT TRUE,
     collection_id uuid REFERENCES public.collections,
-    collection_metadata json
+    collection_metadata json,
+    is_document_group bool DEFAULT FALSE, 
+    document_group_id uuid
 );
 
 -- Changes 5/24/23 --
@@ -44,3 +46,8 @@ ALTER TABLE public.documents ADD COLUMN is_private BOOLEAN DEFAULT true;
 ALTER TABLE public.documents ADD COLUMN collection_id uuid REFERENCES public.collections;
 
 ALTER TABLE public.documents ADD COLUMN collection_metadata json;
+
+-- Changes 05/29/25 --
+ALTER TABLE public.documents ADD COLUMN is_document_group BOOLEAN DEFAULT FALSE;
+
+ALTER TABLE public.documents ADD COLUMN document_group_id uuid; 

--- a/supabase/migrations/20250604193917_enable-group-documents.sql
+++ b/supabase/migrations/20250604193917_enable-group-documents.sql
@@ -1,0 +1,5 @@
+alter table "public"."documents" add column "document_group_id" uuid;
+
+alter table "public"."documents" add column "is_document_group" boolean default false;
+
+

--- a/supabase/migrations/20251016184636_enable_group_documents.sql
+++ b/supabase/migrations/20251016184636_enable_group_documents.sql
@@ -1,5 +1,3 @@
 alter table "public"."documents" add column "document_group_id" uuid;
 
 alter table "public"."documents" add column "is_document_group" boolean default false;
-
-


### PR DESCRIPTION
 @lwjameson I made a new migration with the same content and deleted the old one, since they became out of order and I wanted to prevent conflicts on staging deploy—but this might break your local supabase. I realized afterwards that it looks like the COVE deploys actually use `--include-all` so maybe it wasn't necessary.

Would you prefer that I maintain the old ordering and let `--include-all` do its magic, or stick with this new one?