### PR TITLE
Allow importing docs from project to collection

### DIFF
--- a/SQL Scripts/functions/copy_documents_to_collection_rpc.sql
+++ b/SQL Scripts/functions/copy_documents_to_collection_rpc.sql
@@ -1,0 +1,61 @@
+CREATE OR REPLACE FUNCTION copy_documents_to_collection_rpc(
+    _collection_id uuid,
+    _document_ids uuid[],
+    _collection_metadata json
+)
+RETURNS TABLE (
+    original_document_id uuid,
+    id uuid,
+    collection_id uuid,
+    name varchar,
+    bucket_id text,
+    content_type content_types_type,
+    collection_metadata json
+)
+AS $body$
+BEGIN
+    RETURN QUERY
+    WITH original_documents AS (
+        SELECT
+            documents.id AS original_document_id,
+            gen_random_uuid() AS new_id,
+            documents.name,
+            documents.bucket_id,
+            documents.content_type,
+            documents.meta_data
+        FROM documents
+        WHERE documents.id = ANY(_document_ids)
+    ),
+    new_documents AS (
+        INSERT INTO documents (
+            id,
+            name,
+            bucket_id,
+            content_type,
+            meta_data,
+            collection_id,
+            is_private,
+            collection_metadata
+        )
+        SELECT
+            od.new_id,
+            od.name,
+            od.bucket_id,
+            od.content_type,
+            od.meta_data,
+            _collection_id,
+            FALSE,
+            _collection_metadata
+        FROM original_documents od
+    )
+    SELECT
+        od.original_document_id,
+        od.new_id,
+        _collection_id,
+        od.name,
+        od.bucket_id,
+        od.content_type,
+        _collection_metadata
+    FROM original_documents od;
+END 
+$body$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/migrations/20251020205056_create_copy_documents_to_collection_rpc.sql
+++ b/supabase/migrations/20251020205056_create_copy_documents_to_collection_rpc.sql
@@ -1,0 +1,55 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.copy_documents_to_collection_rpc(_collection_id uuid, _document_ids uuid[], _collection_metadata json)
+ RETURNS TABLE(original_document_id uuid, id uuid, collection_id uuid, name character varying, bucket_id text, content_type content_types_type, collection_metadata json)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+BEGIN
+    RETURN QUERY
+    WITH original_documents AS (
+        SELECT
+            documents.id AS original_document_id,
+            gen_random_uuid() AS new_id,
+            documents.name,
+            documents.bucket_id,
+            documents.content_type,
+            documents.meta_data
+        FROM documents
+        WHERE documents.id = ANY(_document_ids)
+    ),
+    new_documents AS (
+        INSERT INTO documents (
+            id,
+            name,
+            bucket_id,
+            content_type,
+            meta_data,
+            collection_id,
+            is_private,
+            collection_metadata
+        )
+        SELECT
+            od.new_id,
+            od.name,
+            od.bucket_id,
+            od.content_type,
+            od.meta_data,
+            _collection_id,
+            FALSE,
+            _collection_metadata
+        FROM original_documents od
+    )
+    SELECT
+        od.original_document_id,
+        od.new_id,
+        _collection_id,
+        od.name,
+        od.bucket_id,
+        od.content_type,
+        _collection_metadata
+    FROM original_documents od;
+END 
+$function$
+;
+

--- a/supabase/migrations/20251021184515_update_copy_documents_to_collection_rpc.sql
+++ b/supabase/migrations/20251021184515_update_copy_documents_to_collection_rpc.sql
@@ -1,17 +1,14 @@
-CREATE OR REPLACE FUNCTION copy_documents_to_collection_rpc(
-    _collection_id uuid,
-    _document_ids uuid[]
-)
-RETURNS TABLE (
-    original_document_id uuid,
-    id uuid,
-    collection_id uuid,
-    name varchar,
-    bucket_id text,
-    content_type content_types_type,
-    collection_metadata json
-)
-AS $body$
+set check_function_bodies = off;
+
+-- drop original function because it has a different signature (3 arguments)
+DROP FUNCTION IF EXISTS public.copy_documents_to_collection_rpc(_collection_id uuid, _document_ids uuid[], _collection_metadata json);
+
+-- create new one with only 2 arguments
+CREATE OR REPLACE FUNCTION public.copy_documents_to_collection_rpc(_collection_id uuid, _document_ids uuid[])
+ RETURNS TABLE(original_document_id uuid, id uuid, collection_id uuid, name character varying, bucket_id text, content_type content_types_type, collection_metadata json)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
 BEGIN
     RETURN QUERY
     WITH original_documents AS (
@@ -63,4 +60,6 @@ BEGIN
         od.new_collection_metadata
     FROM original_documents od;
 END 
-$body$ LANGUAGE plpgsql SECURITY DEFINER;
+$function$
+;
+


### PR DESCRIPTION
### In this PR

A new RPC function that:
- Copies a document's `name`, `bucket_id`, `content_type`, and `meta_data` to a new document record, with the passed `collection_id` and `collection_metadata`
- Generates a new UUID for the new document
- Returns both the new and original UUIDs so that the old document's contents can be immediately fetched from storage by the frontend, and uploaded to the new document