### PR TITLE
Enable new IIIF processing logic and list/count/search/sort on large collections

### DIFF
--- a/SQL Scripts/functions/bulk_upsert_iiif_rpc.sql
+++ b/SQL Scripts/functions/bulk_upsert_iiif_rpc.sql
@@ -1,0 +1,25 @@
+-- Function to bulk upsert documents from a JSON payload of IIIF manifests
+CREATE OR REPLACE FUNCTION public.bulk_upsert_iiif_rpc(payload json)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+BEGIN
+  INSERT INTO documents (name, collection_id, is_private, collection_metadata, meta_data)
+  SELECT 
+    (item->>'name'),
+    (item->>'collection_id')::uuid,
+    (item->>'is_private')::boolean,
+    (item->'collection_metadata'),
+    (item->'meta_data')
+  FROM json_array_elements(payload) AS item
+  ON CONFLICT (collection_id, (meta_data->>'url')) 
+  DO UPDATE SET
+    name = EXCLUDED.name,
+    collection_metadata = EXCLUDED.collection_metadata,
+    meta_data = EXCLUDED.meta_data;
+END;
+$function$
+;
+
+ALTER FUNCTION "public"."bulk_upsert_iiif_rpc" OWNER TO "postgres";

--- a/SQL Scripts/functions/claim_next_iiif_sync_task_rpc.sql
+++ b/SQL Scripts/functions/claim_next_iiif_sync_task_rpc.sql
@@ -1,0 +1,20 @@
+-- RPC that grabs IIIF sync task and updates its status and attempt count
+
+CREATE
+    OR REPLACE FUNCTION claim_next_iiif_sync_task_rpc()
+    RETURNS SETOF iiif_sync_status AS $body$
+BEGIN
+  RETURN QUERY
+  UPDATE iiif_sync_status
+  SET status = 'PROCESSING', attempt_count = attempt_count + 1
+  WHERE id = (
+    SELECT id
+    FROM iiif_sync_status
+    WHERE status = 'INITIALIZING'
+    ORDER BY created_at
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED -- Prevent race condition; see https://www.netdata.cloud/academy/update-skip-locked/
+  )
+  RETURNING *;
+END;
+$body$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/SQL Scripts/functions/get_library_documents_rpc.sql
+++ b/SQL Scripts/functions/get_library_documents_rpc.sql
@@ -1,0 +1,58 @@
+-- function to get library documents:
+--   always 1 revision per document (latest)
+--   sortable on name, author
+--   searchable on name, author
+
+CREATE OR REPLACE FUNCTION public.get_library_documents_rpc(_collection_id uuid, _user_id uuid, _is_mine boolean DEFAULT false, _search text DEFAULT ''::text, _limit integer DEFAULT 50, _offset integer DEFAULT 0, _sort_by text DEFAULT 'name'::text, _sort_dir text DEFAULT 'asc'::text)
+ RETURNS TABLE(id uuid, name character varying, content_type text, created_at timestamp with time zone, created_by uuid, is_private boolean, collection_id uuid, collection_document_id text, revision_number integer, meta_data json, is_document_group boolean, document_group_id uuid)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+BEGIN
+    RETURN QUERY
+    SELECT
+        d.id, d.name, d.content_type::text, d.created_at, d.created_by, d.is_private, 
+        d.collection_id, d.collection_document_id, d.revision_number, d.meta_data,
+        d.is_document_group, d.document_group_id
+    FROM (
+        -- only select one revision per document, per collection
+        SELECT DISTINCT ON (doc.collection_id, doc.collection_document_id) doc.*
+        FROM documents doc
+        WHERE doc.is_archived = false
+            AND (
+            -- my documents
+            (_is_mine AND doc.created_by = _user_id AND doc.collection_id IS NULL) OR
+            -- collection documents
+            (_collection_id IS NOT NULL AND doc.collection_id = _collection_id) OR
+            -- all public documents
+            (NOT _is_mine AND _collection_id IS NULL AND doc.is_private = false AND doc.collection_id IS NULL)
+            )
+        -- search (will use trigram)
+        AND (
+            _search = ''
+            OR doc.name ILIKE '%' || _search || '%'
+            OR doc.author ILIKE '%' || _search || '%'
+        )
+        -- choose the latest revision
+        ORDER BY
+            doc.collection_id,
+            doc.collection_document_id,
+            doc.revision_number DESC NULLS LAST,
+            doc.created_at DESC,
+            doc.id DESC
+    ) d
+    -- allow sorting by sort params
+    ORDER BY
+        CASE
+            WHEN _sort_by = 'name' AND _sort_dir = 'asc' THEN d.name
+            WHEN _sort_by = 'author' AND _sort_dir = 'asc' THEN d.author
+        END ASC,
+        CASE
+            WHEN _sort_by = 'name' AND _sort_dir = 'desc' THEN d.name
+            WHEN _sort_by = 'author' AND _sort_dir = 'desc' THEN d.author
+        END DESC,
+        d.id ASC
+    LIMIT _limit OFFSET _offset;
+    END;
+$function$
+;

--- a/SQL Scripts/functions/set_document_author.sql
+++ b/SQL Scripts/functions/set_document_author.sql
@@ -1,0 +1,22 @@
+-- function to set the author on a generated document column from iiif metadata
+CREATE OR REPLACE FUNCTION public.set_document_author()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    -- clear old value if present
+    NEW.author := NULL;
+    -- handle meta_data not being an actual json array; unlikely but could happen
+    IF json_typeof(NEW.meta_data->'meta') = 'array' THEN
+       -- find the author/artist value from iiif
+        NEW.author := (
+            SELECT elem->>'value'
+            FROM json_array_elements(NEW.meta_data->'meta') AS elem
+            WHERE lower(elem->>'label') IN ('author', 'artist')
+            LIMIT 1
+        );
+    END IF;
+    RETURN NEW;
+END;
+$function$
+;

--- a/SQL Scripts/functions/sync_collection_document_count.sql
+++ b/SQL Scripts/functions/sync_collection_document_count.sql
@@ -1,0 +1,83 @@
+-- function to update collection document count when documents are added/removed from collection
+
+CREATE OR REPLACE FUNCTION public.sync_collection_document_count()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    has_revision boolean;
+BEGIN
+    IF (TG_OP = 'UPDATE') THEN
+        -- handle deletion (archiving; decrement)
+        IF (OLD.is_archived = false AND NEW.is_archived = true AND NEW.collection_id IS NOT NULL) THEN
+            SELECT EXISTS (
+                SELECT 1 FROM public.documents 
+                WHERE collection_document_id = NEW.collection_document_id 
+                AND collection_id = NEW.collection_id
+                AND id != NEW.id 
+                AND is_archived = false
+            ) INTO has_revision;
+
+            IF NOT has_revision THEN
+                UPDATE public.collections SET document_count = document_count - 1 WHERE id = NEW.collection_id;
+            END IF;
+        
+        -- handle un-archiving (increment)
+        ELSIF (OLD.is_archived = true AND NEW.is_archived = false AND NEW.collection_id IS NOT NULL) THEN
+             SELECT EXISTS (
+                SELECT 1 FROM public.documents 
+                WHERE collection_document_id = NEW.collection_document_id 
+                AND collection_id = NEW.collection_id
+                AND id != NEW.id 
+                AND is_archived = false
+            ) INTO has_revision;
+
+            IF NOT has_revision THEN
+                UPDATE public.collections SET document_count = document_count + 1 WHERE id = NEW.collection_id;
+            END IF;
+
+        -- handle potential move between collections (possible in sql but not UI)
+        ELSIF (OLD.collection_id IS DISTINCT FROM NEW.collection_id AND NEW.is_archived = false) THEN
+            IF (OLD.collection_id IS NOT NULL) THEN
+                UPDATE public.collections SET document_count = document_count - 1 WHERE id = OLD.collection_id;
+            END IF;
+            IF (NEW.collection_id IS NOT NULL) THEN
+                UPDATE public.collections SET document_count = document_count + 1 WHERE id = NEW.collection_id;
+            END IF;
+        END IF;
+
+    -- increment on create
+    ELSIF (TG_OP = 'INSERT' AND NEW.collection_id IS NOT NULL AND NEW.is_archived = false) THEN
+        -- check for other revisions first
+        SELECT EXISTS (
+            SELECT 1 FROM public.documents 
+            WHERE collection_document_id = NEW.collection_document_id 
+            AND collection_id = NEW.collection_id
+            AND id != NEW.id 
+            AND is_archived = false
+        ) INTO has_revision;
+
+        -- only increment if no other revisions, since a revision doesn't count as a new doc
+        IF NOT has_revision THEN
+            UPDATE public.collections SET document_count = document_count + 1 WHERE id = NEW.collection_id;
+        END IF;
+
+    -- decrement on actual sql DELETE (possible in sql but not UI)
+    ELSIF (TG_OP = 'DELETE' AND OLD.collection_id IS NOT NULL AND OLD.is_archived = false) THEN
+        SELECT EXISTS (
+            SELECT 1 FROM public.documents 
+            WHERE collection_document_id = OLD.collection_document_id 
+            AND collection_id = NEW.collection_id
+            AND id != OLD.id 
+            AND is_archived = false
+        ) INTO has_revision;
+
+        IF NOT has_revision THEN
+            UPDATE public.collections SET document_count = document_count - 1 WHERE id = OLD.collection_id;
+        END IF;
+    END IF;
+
+    RETURN NULL;
+END;
+$function$
+;

--- a/SQL Scripts/policies/iiif_sync_status.sql
+++ b/SQL Scripts/policies/iiif_sync_status.sql
@@ -1,0 +1,3 @@
+DROP POLICY IF EXISTS "Service role has full access" ON public.iiif_sync_status;
+
+CREATE POLICY "Service role has full access" ON "public"."iiif_sync_status" FOR ALL TO "service_role" USING (true) WITH CHECK (true);

--- a/SQL Scripts/tables/collections.sql
+++ b/SQL Scripts/tables/collections.sql
@@ -1,14 +1,24 @@
 CREATE TABLE public.collections (
-    id uuid NOT NULL DEFAULT uuid_generate_v4 () PRIMARY KEY,
-    created_at timestamp WITH TIME ZONE DEFAULT NOW(),
-    created_by uuid REFERENCES public.profiles,
-    updated_at timestamptz,
-    updated_by uuid REFERENCES public.profiles,
-    name varchar NOT NULL,
-    extension_id uuid REFERENCES public.extensions,
-    extension_metadata json,
-    is_archived: BOOLEAN DEFAULT FALSE
+    id uuid             DEFAULT extensions.uuid_generate_v4() NOT NULL,
+    created_at          timestamp with time zone DEFAULT now(),
+    created_by          uuid,
+    updated_at          timestamp with time zone,
+    updated_by          uuid,
+    name                character varying NOT NULL,
+    extension_id        uuid,
+    extension_metadata  json,
+    custom_css          text,
+    is_archived         boolean DEFAULT false,
+    document_count      bigint DEFAULT 0
 );
+
+-- Changes 01.05.24 --
+alter table "public"."collections" add column "custom_css" text;
 
 -- Changes 02.15.24 --
 ALTER TABLE public.collections ADD COLUMN is_archived BOOLEAN DEFAULT FALSE;
+
+-- Changes 01.14.26 --
+alter table "public"."collections" add column "document_count" bigint default 0;
+
+CREATE INDEX IF NOT EXISTS collection_documents_count_idx ON public.documents USING btree (collection_document_id) WHERE (is_archived = false);

--- a/SQL Scripts/tables/documents.sql
+++ b/SQL Scripts/tables/documents.sql
@@ -3,21 +3,24 @@ CREATE TYPE content_types_type AS ENUM ('text/markdown', 'image/jpeg', 'image/ti
 
 CREATE TABLE public.documents
 (
-    id           uuid               NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
-    created_at   timestamp WITH TIME ZONE    DEFAULT NOW(),
-    created_by   uuid REFERENCES public.profiles,
-    updated_at   timestamptz,
-    updated_by   uuid REFERENCES public.profiles,
-    is_archived  bool                        DEFAULT FALSE,
-    name         varchar            NOT NULL,
-    bucket_id    text,
-    content_type content_types_type,
-    meta_data    json DEFAULT '{}'::json,
-    is_private   BOOLEAN DEFAULT TRUE,
-    collection_id uuid REFERENCES public.collections,
-    collection_metadata json,
-    is_document_group bool DEFAULT FALSE, 
-    document_group_id uuid
+    id                      uuid                        DEFAULT extensions.uuid_generate_v4()   NOT NULL,
+    created_at              timestamp with time zone    DEFAULT now(),
+    created_by              uuid,
+    updated_at              timestamp with time zone,
+    updated_by              uuid,
+    is_archived             boolean                     DEFAULT false,
+    name                    character varying           NOT NULL,
+    bucket_id               text,
+    content_type            public.content_types_type,
+    meta_data               json                        DEFAULT '{}'::json                      NOT NULL,
+    is_private              boolean                     DEFAULT true,
+    collection_id           uuid,
+    collection_metadata     json,
+    is_document_group       boolean                     DEFAULT false,
+    document_group_id       uuid,
+    collection_document_id  text                        GENERATED ALWAYS AS (COALESCE((collection_metadata ->> 'document_id'::text), (id)::text)) STORED,
+    revision_number         integer                     GENERATED ALWAYS AS ((NULLIF((collection_metadata ->> 'revision_number'::text), ''::text))::integer) STORED,
+    author                  text
 );
 
 -- Changes 5/24/23 --
@@ -51,3 +54,20 @@ ALTER TABLE public.documents ADD COLUMN collection_metadata json;
 ALTER TABLE public.documents ADD COLUMN is_document_group BOOLEAN DEFAULT FALSE;
 
 ALTER TABLE public.documents ADD COLUMN document_group_id uuid; 
+
+-- Changes 01/14/26 --
+-- Unique index to ensure we don't insert duplicate documents per collection based on the manifest URL
+CREATE UNIQUE INDEX IF NOT EXISTS documents_unique_collection_id_url ON documents (collection_id, ((meta_data ->> 'url')));
+
+-- add generated columns from collection metadata (doc id, revision number, authorship metadata)
+alter table "public"."documents" add column if not exists "collection_document_id" text generated always as (COALESCE((collection_metadata ->> 'document_id'::text), (id)::text)) stored;
+
+alter table "public"."documents" add column if not exists "revision_number" integer generated always as ((NULLIF((collection_metadata ->> 'revision_number'::text), ''::text))::integer) stored;
+
+-- index collection documents for fast retrieval
+CREATE INDEX IF NOT EXISTS collection_documents_idx ON public.documents USING btree (collection_id, collection_document_id, revision_number DESC, created_at DESC, id DESC) WHERE (is_archived = false);
+
+-- store and index authorship info (always pulled from iiif, not editable in UI)
+alter table "public"."documents" add column IF NOT EXISTS "author" text;
+CREATE INDEX IF NOT EXISTS document_library_name_sort_idx ON public.documents (name) WHERE (is_archived = false);
+CREATE INDEX IF NOT EXISTS document_library_author_sort_idx ON public.documents (author) WHERE (is_archived = false);

--- a/SQL Scripts/tables/iiif_sync_status.sql
+++ b/SQL Scripts/tables/iiif_sync_status.sql
@@ -1,0 +1,43 @@
+-- IIIF sync status table to track progress syncing multiple large
+-- collections of IIIF manifests from Google Sheets via AWS/DO. Essentially,
+-- a highly simplified PSQL-backed job queue.
+
+CREATE TABLE public.iiif_sync_status (
+    id              uuid                        DEFAULT extensions.uuid_generate_v4()   NOT NULL,
+    created_at      timestamp with time zone    DEFAULT now(),
+    collection_id   uuid,
+    iiif_url        text                        NOT NULL,
+    chunk_index     integer                     NOT NULL,
+    status          public.job_statuses         DEFAULT 'INITIALIZING'::public.job_statuses,
+    error           text,
+    attempt_count   integer                     DEFAULT 0
+);
+
+-- Only grant permissions to service_role, this table is only used internally.
+
+ALTER TABLE "public"."iiif_sync_status" ENABLE ROW LEVEL SECURITY;
+
+revoke all on table "public"."iiif_sync_status" from "anon";
+
+revoke all on table "public"."iiif_sync_status" from "authenticated";
+
+grant delete on table "public"."iiif_sync_status" to "service_role";
+
+grant insert on table "public"."iiif_sync_status" to "service_role";
+
+grant references on table "public"."iiif_sync_status" to "service_role";
+
+grant select on table "public"."iiif_sync_status" to "service_role";
+
+grant trigger on table "public"."iiif_sync_status" to "service_role";
+
+grant truncate on table "public"."iiif_sync_status" to "service_role";
+
+grant update on table "public"."iiif_sync_status" to "service_role";
+
+
+-- Index for the edge function to efficiently claim the next task
+CREATE INDEX IF NOT EXISTS "idx_iiif_sync_status_pending" ON "public"."iiif_sync_status" (status) WHERE status = 'INITIALIZING';
+
+-- Unique index on collection+chunk so that upsert will not produce extra task rows
+CREATE UNIQUE INDEX IF NOT EXISTS "uniq_iiif_collection_chunk" ON "public"."iiif_sync_status" (collection_id, chunk_index);

--- a/SQL Scripts/triggers/documents/on_document_updated_set_author.sql
+++ b/SQL Scripts/triggers/documents/on_document_updated_set_author.sql
@@ -1,0 +1,3 @@
+-- trigger function to set the author on a generated document column from iiif metadata
+
+CREATE TRIGGER on_document_updated_set_author BEFORE INSERT OR UPDATE OF meta_data ON public.documents FOR EACH ROW EXECUTE FUNCTION public.set_document_author();

--- a/SQL Scripts/triggers/documents/on_document_updated_update_collection_count.sql
+++ b/SQL Scripts/triggers/documents/on_document_updated_update_collection_count.sql
@@ -1,0 +1,3 @@
+-- trigger to sync collection counter cache when documents change
+
+CREATE TRIGGER on_document_updated_update_collection_count AFTER INSERT OR DELETE OR UPDATE ON public.documents FOR EACH ROW EXECUTE FUNCTION public.sync_collection_document_count();

--- a/supabase/migrations/20260108212922_create_collection_document_index.sql
+++ b/supabase/migrations/20260108212922_create_collection_document_index.sql
@@ -1,0 +1,3 @@
+-- Unique index to ensure we don't insert duplicate documents
+-- per collection based on the manifest URL
+CREATE UNIQUE INDEX IF NOT EXISTS documents_unique_collection_id_url ON documents (collection_id, ((meta_data ->> 'url')));

--- a/supabase/migrations/20260108231505_bulk_upsert_iiif_rpc.sql
+++ b/supabase/migrations/20260108231505_bulk_upsert_iiif_rpc.sql
@@ -1,0 +1,28 @@
+create extension if not exists "pgaudit" with schema "extensions";
+
+-- Function to bulk upsert documents from a JSON payload of IIIF manifests
+set check_function_bodies = off;
+CREATE OR REPLACE FUNCTION public.bulk_upsert_iiif_rpc(payload json)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+BEGIN
+  INSERT INTO documents (name, collection_id, is_private, collection_metadata, meta_data)
+  SELECT 
+    (item->>'name'),
+    (item->>'collection_id')::uuid,
+    (item->>'is_private')::boolean,
+    (item->'collection_metadata'),
+    (item->'meta_data')
+  FROM json_array_elements(payload) AS item
+  ON CONFLICT (collection_id, (meta_data->>'url')) 
+  DO UPDATE SET
+    name = EXCLUDED.name,
+    collection_metadata = EXCLUDED.collection_metadata,
+    meta_data = EXCLUDED.meta_data;
+END;
+$function$
+;
+
+ALTER FUNCTION "public"."bulk_upsert_iiif_rpc" OWNER TO "postgres";

--- a/supabase/migrations/20260108231516_create_iiif_sync_status.sql
+++ b/supabase/migrations/20260108231516_create_iiif_sync_status.sql
@@ -1,0 +1,66 @@
+-- Create a IIIF sync status table to track progress syncing multiple large
+-- collections of IIIF manifests from Google Sheets via AWS/DO. Essentially,
+-- a highly simplified PSQL-backed job queue.
+
+CREATE TABLE IF NOT EXISTS "public"."iiif_sync_status" (
+    "id" uuid NOT NULL default uuid_generate_v4() PRIMARY KEY,
+    "created_at" timestamp with time zone default now(),
+    "collection_id" uuid REFERENCES collections(id) ON DELETE CASCADE,
+    "iiif_url" text NOT NULL,
+    "chunk_index" int NOT NULL,
+    "status" job_statuses default 'INITIALIZING',
+    "error" text,
+    "attempt_count" int default 0
+);
+
+-- Only grant permissions to service_role, this table is only used internally.
+
+ALTER TABLE "public"."iiif_sync_status" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role has full access" ON "public"."iiif_sync_status" FOR ALL TO "service_role" USING (true) WITH CHECK (true);
+
+revoke all on table "public"."iiif_sync_status" from "anon";
+
+revoke all on table "public"."iiif_sync_status" from "authenticated";
+
+grant delete on table "public"."iiif_sync_status" to "service_role";
+
+grant insert on table "public"."iiif_sync_status" to "service_role";
+
+grant references on table "public"."iiif_sync_status" to "service_role";
+
+grant select on table "public"."iiif_sync_status" to "service_role";
+
+grant trigger on table "public"."iiif_sync_status" to "service_role";
+
+grant truncate on table "public"."iiif_sync_status" to "service_role";
+
+grant update on table "public"."iiif_sync_status" to "service_role";
+
+
+-- Index for the edge function to efficiently claim the next task
+CREATE INDEX IF NOT EXISTS "idx_iiif_sync_status_pending" ON "public"."iiif_sync_status" (status) WHERE status = 'INITIALIZING';
+
+-- Unique index on collection+chunk so that upsert will not produce extra task rows
+CREATE UNIQUE INDEX IF NOT EXISTS "uniq_iiif_collection_chunk" ON "public"."iiif_sync_status" (collection_id, chunk_index);
+
+-- RPC that grabs IIIF sync task and updates its status and attempt count
+
+CREATE
+    OR REPLACE FUNCTION claim_next_iiif_sync_task_rpc()
+    RETURNS SETOF iiif_sync_status AS $body$
+BEGIN
+  RETURN QUERY
+  UPDATE iiif_sync_status
+  SET status = 'PROCESSING', attempt_count = attempt_count + 1
+  WHERE id = (
+    SELECT id
+    FROM iiif_sync_status
+    WHERE status = 'INITIALIZING'
+    ORDER BY created_at
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED -- Prevent race condition; see https://www.netdata.cloud/academy/update-skip-locked/
+  )
+  RETURNING *;
+END;
+$body$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/migrations/20260112185945_collection_documents_index.sql
+++ b/supabase/migrations/20260112185945_collection_documents_index.sql
@@ -1,0 +1,7 @@
+-- add generated columns from collection metadata (doc id, revision number, authorship metadata)
+alter table "public"."documents" add column if not exists "collection_document_id" text generated always as (COALESCE((collection_metadata ->> 'document_id'::text), (id)::text)) stored;
+
+alter table "public"."documents" add column if not exists "revision_number" integer generated always as ((NULLIF((collection_metadata ->> 'revision_number'::text), ''::text))::integer) stored;
+
+-- index collection documents for fast retrieval
+CREATE INDEX IF NOT EXISTS collection_documents_idx ON public.documents USING btree (collection_id, collection_document_id, revision_number DESC, created_at DESC, id DESC) WHERE (is_archived = false);

--- a/supabase/migrations/20260112225522_collection_counter_cache.sql
+++ b/supabase/migrations/20260112225522_collection_counter_cache.sql
@@ -1,0 +1,112 @@
+-- add counter cache for collections to track document counts efficiently
+
+alter table "public"."collections" add column "document_count" bigint default 0;
+
+CREATE INDEX IF NOT EXISTS collection_documents_count_idx ON public.documents USING btree (collection_document_id) WHERE (is_archived = false);
+
+-- set initial counts
+UPDATE public.collections c
+SET document_count = documents_subquery.actual_count
+FROM (
+    SELECT 
+        collection_id, 
+        COUNT(DISTINCT collection_document_id) as actual_count
+    FROM public.documents
+    WHERE is_archived = false 
+      AND collection_id IS NOT NULL
+    GROUP BY collection_id
+) documents_subquery
+WHERE c.id = documents_subquery.collection_id;
+
+
+-- add trigger function to sync counter cache when documents change
+
+DROP TRIGGER IF EXISTS on_document_updated_update_collection_count ON public.documents;
+
+DROP FUNCTION IF EXISTS public.sync_collection_document_count;
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.sync_collection_document_count()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    has_revision boolean;
+BEGIN
+    IF (TG_OP = 'UPDATE') THEN
+        -- handle deletion (archiving; decrement)
+        IF (OLD.is_archived = false AND NEW.is_archived = true AND NEW.collection_id IS NOT NULL) THEN
+            SELECT EXISTS (
+                SELECT 1 FROM public.documents 
+                WHERE collection_document_id = NEW.collection_document_id 
+                AND collection_id = NEW.collection_id
+                AND id != NEW.id 
+                AND is_archived = false
+            ) INTO has_revision;
+
+            IF NOT has_revision THEN
+                UPDATE public.collections SET document_count = document_count - 1 WHERE id = NEW.collection_id;
+            END IF;
+        
+        -- handle un-archiving (increment)
+        ELSIF (OLD.is_archived = true AND NEW.is_archived = false AND NEW.collection_id IS NOT NULL) THEN
+             SELECT EXISTS (
+                SELECT 1 FROM public.documents 
+                WHERE collection_document_id = NEW.collection_document_id 
+                AND collection_id = NEW.collection_id
+                AND id != NEW.id 
+                AND is_archived = false
+            ) INTO has_revision;
+
+            IF NOT has_revision THEN
+                UPDATE public.collections SET document_count = document_count + 1 WHERE id = NEW.collection_id;
+            END IF;
+
+        -- handle potential move between collections (possible in sql but not UI)
+        ELSIF (OLD.collection_id IS DISTINCT FROM NEW.collection_id AND NEW.is_archived = false) THEN
+            IF (OLD.collection_id IS NOT NULL) THEN
+                UPDATE public.collections SET document_count = document_count - 1 WHERE id = OLD.collection_id;
+            END IF;
+            IF (NEW.collection_id IS NOT NULL) THEN
+                UPDATE public.collections SET document_count = document_count + 1 WHERE id = NEW.collection_id;
+            END IF;
+        END IF;
+
+    -- increment on create
+    ELSIF (TG_OP = 'INSERT' AND NEW.collection_id IS NOT NULL AND NEW.is_archived = false) THEN
+        -- check for other revisions first
+        SELECT EXISTS (
+            SELECT 1 FROM public.documents 
+            WHERE collection_document_id = NEW.collection_document_id 
+            AND collection_id = NEW.collection_id
+            AND id != NEW.id 
+            AND is_archived = false
+        ) INTO has_revision;
+
+        -- only increment if no other revisions, since a revision doesn't count as a new doc
+        IF NOT has_revision THEN
+            UPDATE public.collections SET document_count = document_count + 1 WHERE id = NEW.collection_id;
+        END IF;
+
+    -- decrement on actual sql DELETE (possible in sql but not UI)
+    ELSIF (TG_OP = 'DELETE' AND OLD.collection_id IS NOT NULL AND OLD.is_archived = false) THEN
+        SELECT EXISTS (
+            SELECT 1 FROM public.documents 
+            WHERE collection_document_id = OLD.collection_document_id 
+            AND collection_id = NEW.collection_id
+            AND id != OLD.id 
+            AND is_archived = false
+        ) INTO has_revision;
+
+        IF NOT has_revision THEN
+            UPDATE public.collections SET document_count = document_count - 1 WHERE id = OLD.collection_id;
+        END IF;
+    END IF;
+
+    RETURN NULL;
+END;
+$function$
+;
+
+CREATE TRIGGER on_document_updated_update_collection_count AFTER INSERT OR DELETE OR UPDATE ON public.documents FOR EACH ROW EXECUTE FUNCTION public.sync_collection_document_count();

--- a/supabase/migrations/20260113191645_document_library.sql
+++ b/supabase/migrations/20260113191645_document_library.sql
@@ -1,0 +1,111 @@
+-- trigger function to set the author on a generated document column* from iiif metadata
+-- (*technically not a generated column, but this is the closest we can get w/ json).
+-- needed so we can sort/search on author.
+alter table "public"."documents" add column IF NOT EXISTS "author" text;
+CREATE INDEX IF NOT EXISTS document_library_name_sort_idx ON public.documents (name) WHERE (is_archived = false);
+CREATE INDEX IF NOT EXISTS document_library_author_sort_idx ON public.documents (author) WHERE (is_archived = false);
+
+DROP TRIGGER IF EXISTS on_document_updated_set_author ON public.documents;
+DROP FUNCTION IF EXISTS public.set_document_author;
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.set_document_author()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    -- clear old value if present
+    NEW.author := NULL;
+    -- handle meta_data not being an actual json array; unlikely but could happen
+    IF json_typeof(NEW.meta_data->'meta') = 'array' THEN
+       -- find the author/artist value from iiif
+        NEW.author := (
+            SELECT elem->>'value'
+            FROM json_array_elements(NEW.meta_data->'meta') AS elem
+            WHERE lower(elem->>'label') IN ('author', 'artist')
+            LIMIT 1
+        );
+    END IF;
+    RETURN NEW;
+END;
+$function$
+;
+
+CREATE TRIGGER on_document_updated_set_author BEFORE INSERT OR UPDATE OF meta_data ON public.documents FOR EACH ROW EXECUTE FUNCTION public.set_document_author();
+
+-- data migration to populate author/artist for existing docs
+UPDATE public.documents 
+SET author = (
+    SELECT elem->>'value'
+    FROM json_array_elements(meta_data->'meta') AS elem
+    WHERE lower(elem->>'label') IN ('author', 'artist')
+    LIMIT 1
+)
+WHERE is_archived = false 
+  AND json_typeof(meta_data->'meta') = 'array';
+
+-- enable trigram search
+create extension if not exists "pg_trgm" with schema "public";
+
+CREATE INDEX IF NOT EXISTS idx_documents_search_trgm ON public.documents USING gin (name public.gin_trgm_ops, author public.gin_trgm_ops) WHERE (is_archived = false);
+
+-- function to get library documents:
+--   always 1 revision per document (latest)
+--   sortable on name, author
+--   searchable on name, author
+DROP FUNCTION IF EXISTS public.get_library_documents_rpc(_collection_id uuid, _user_id uuid, _is_mine boolean, _search text, _limit integer, _offset integer, _sort_by text, _sort_dir text);
+
+CREATE OR REPLACE FUNCTION public.get_library_documents_rpc(_collection_id uuid, _user_id uuid, _is_mine boolean DEFAULT false, _search text DEFAULT ''::text, _limit integer DEFAULT 50, _offset integer DEFAULT 0, _sort_by text DEFAULT 'name'::text, _sort_dir text DEFAULT 'asc'::text)
+ RETURNS TABLE(id uuid, name character varying, content_type text, created_at timestamp with time zone, created_by uuid, is_private boolean, collection_id uuid, collection_document_id text, revision_number integer, meta_data json, is_document_group boolean, document_group_id uuid)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+BEGIN
+    RETURN QUERY
+    SELECT
+        d.id, d.name, d.content_type::text, d.created_at, d.created_by, d.is_private, 
+        d.collection_id, d.collection_document_id, d.revision_number, d.meta_data,
+        d.is_document_group, d.document_group_id
+    FROM (
+        -- only select one revision per document, per collection
+        SELECT DISTINCT ON (doc.collection_id, doc.collection_document_id) doc.*
+        FROM documents doc
+        WHERE doc.is_archived = false
+            AND (
+            -- my documents
+            (_is_mine AND doc.created_by = _user_id AND doc.collection_id IS NULL) OR
+            -- collection documents
+            (_collection_id IS NOT NULL AND doc.collection_id = _collection_id) OR
+            -- all public documents
+            (NOT _is_mine AND _collection_id IS NULL AND doc.is_private = false AND doc.collection_id IS NULL)
+            )
+        -- search (will use trigram)
+        AND (
+            _search = ''
+            OR doc.name ILIKE '%' || _search || '%'
+            OR doc.author ILIKE '%' || _search || '%'
+        )
+        -- choose the latest revision
+        ORDER BY
+            doc.collection_id,
+            doc.collection_document_id,
+            doc.revision_number DESC NULLS LAST,
+            doc.created_at DESC,
+            doc.id DESC
+    ) d
+    -- allow sorting by sort params
+    ORDER BY
+        CASE
+            WHEN _sort_by = 'name' AND _sort_dir = 'asc' THEN d.name
+            WHEN _sort_by = 'author' AND _sort_dir = 'asc' THEN d.author
+        END ASC,
+        CASE
+            WHEN _sort_by = 'name' AND _sort_dir = 'desc' THEN d.name
+            WHEN _sort_by = 'author' AND _sort_dir = 'desc' THEN d.author
+        END DESC,
+        d.id ASC
+    LIMIT _limit OFFSET _offset;
+    END;
+$function$
+;

--- a/supabase/migrations/20260120203553_document_library_sorting.sql
+++ b/supabase/migrations/20260120203553_document_library_sorting.sql
@@ -1,0 +1,63 @@
+-- update library docs function for improved sorting logic (nulls last)
+
+DROP FUNCTION IF EXISTS public.get_library_documents_rpc(_collection_id uuid, _user_id uuid, _is_mine boolean, _search text, _limit integer, _offset integer, _sort_by text, _sort_dir text);
+
+CREATE OR REPLACE FUNCTION public.get_library_documents_rpc(_collection_id uuid, _user_id uuid, _is_mine boolean DEFAULT false, _search text DEFAULT ''::text, _limit integer DEFAULT 50, _offset integer DEFAULT 0, _sort_by text DEFAULT 'name'::text, _sort_dir text DEFAULT 'asc'::text)
+ RETURNS TABLE(id uuid, name character varying, content_type text, created_at timestamp with time zone, created_by uuid, is_private boolean, collection_id uuid, collection_document_id text, revision_number integer, meta_data json, is_document_group boolean, document_group_id uuid)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+BEGIN
+    RETURN QUERY
+    SELECT
+        d.id, d.name, d.content_type::text, d.created_at, d.created_by, d.is_private, 
+        d.collection_id, d.collection_document_id, d.revision_number, d.meta_data,
+        d.is_document_group, d.document_group_id
+    FROM (
+        -- only select one revision per document, per collection
+        SELECT DISTINCT ON (doc.collection_id, doc.collection_document_id) doc.*
+        FROM documents doc
+        WHERE doc.is_archived = false
+            AND (
+            -- my documents
+            (_is_mine AND doc.created_by = _user_id AND doc.collection_id IS NULL) OR
+            -- collection documents
+            (_collection_id IS NOT NULL AND doc.collection_id = _collection_id) OR
+            -- all public documents
+            (NOT _is_mine AND _collection_id IS NULL AND doc.is_private = false AND doc.collection_id IS NULL)
+            )
+        -- search (will use trigram)
+        AND (
+            _search = ''
+            OR doc.name ILIKE '%' || _search || '%'
+            OR doc.author ILIKE '%' || _search || '%'
+        )
+        -- choose the latest revision
+        ORDER BY
+            doc.collection_id,
+            doc.collection_document_id,
+            doc.revision_number DESC NULLS LAST,
+            doc.created_at DESC,
+            doc.id DESC
+    ) d
+    -- allow sorting by sort params
+    ORDER BY
+        CASE
+            -- sort nulls and empty strings last 
+            WHEN _sort_by = 'name' AND (d.name IS NULL OR d.name = '') THEN 1
+            WHEN _sort_by = 'author' AND (d.author IS NULL OR d.author = '') THEN 1
+            ELSE 0
+        END ASC,
+        CASE
+            WHEN _sort_by = 'name' AND _sort_dir = 'asc' THEN d.name
+            WHEN _sort_by = 'author' AND _sort_dir = 'asc' THEN d.author
+        END ASC,
+        CASE
+            WHEN _sort_by = 'name' AND _sort_dir = 'desc' THEN d.name
+            WHEN _sort_by = 'author' AND _sort_dir = 'desc' THEN d.author
+        END DESC,
+        d.id ASC
+    LIMIT _limit OFFSET _offset;
+    END;
+$function$
+;

--- a/supabase/migrations/20260120212156_collection_documents_rpc.sql
+++ b/supabase/migrations/20260120212156_collection_documents_rpc.sql
@@ -1,0 +1,141 @@
+-- add an RPC for getting collection documents for the collection management UI.
+-- similar to the library one, but simpler (searching but no sorting) and
+-- includes revision counts and total result counts.
+
+set check_function_bodies = off;
+
+DROP FUNCTION IF EXISTS public.get_collection_management_documents_rpc(_collection_id uuid, _search text, _limit integer, _offset integer);
+
+CREATE OR REPLACE FUNCTION public.get_collection_management_documents_rpc(_collection_id uuid, _search text DEFAULT ''::text, _limit integer DEFAULT 50, _offset integer DEFAULT 0)
+ RETURNS TABLE(id uuid, name character varying, content_type text, revision_count bigint, latest_revision_number integer, collection_metadata json, total_count bigint)
+ LANGUAGE plpgsql
+AS $function$
+ BEGIN
+    RETURN QUERY
+    WITH grouped_docs AS (
+        SELECT 
+            d.id,
+            d.name,
+            d.content_type,
+            d.collection_metadata,
+            -- calculate total revisions for this document by collection_document_id
+            COUNT(*) OVER(PARTITION BY d.collection_document_id) as revision_count,
+            -- rank them to find the latest
+            ROW_NUMBER() OVER(
+                PARTITION BY d.collection_document_id 
+                ORDER BY d.revision_number DESC, d.created_at DESC
+            ) as rank
+        FROM documents d
+        WHERE d.is_archived = false
+          AND d.collection_id = _collection_id
+          AND (
+            _search = '' OR 
+            d.name ILIKE '%' || _search || '%'
+          )
+    )
+    SELECT 
+        gd.id, 
+        gd.name, 
+        gd.content_type::text, 
+        gd.revision_count, 
+        (gd.collection_metadata->>'revision_number')::int,
+        gd.collection_metadata,
+        COUNT(*) OVER() as total_count
+    FROM grouped_docs gd
+    WHERE gd.rank = 1
+    ORDER BY gd.name ASC
+    LIMIT _limit OFFSET _offset;
+ END;
+ $function$
+;
+
+-- this one actually didn't change but supabase db diff is saying it doesn't match,
+-- so just including it here for my local's sake. (will have no effect elsewhere)
+
+DROP TRIGGER IF EXISTS on_document_updated_update_collection_count ON public.documents;
+
+DROP FUNCTION IF EXISTS public.sync_collection_document_count();
+
+CREATE OR REPLACE FUNCTION public.sync_collection_document_count()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    has_revision boolean;
+BEGIN
+    IF (TG_OP = 'UPDATE') THEN
+        -- handle deletion (archiving; decrement)
+        IF (OLD.is_archived = false AND NEW.is_archived = true AND NEW.collection_id IS NOT NULL) THEN
+            SELECT EXISTS (
+                SELECT 1 FROM public.documents 
+                WHERE collection_document_id = NEW.collection_document_id 
+                AND collection_id = NEW.collection_id
+                AND id != NEW.id 
+                AND is_archived = false
+            ) INTO has_revision;
+
+            IF NOT has_revision THEN
+                UPDATE public.collections SET document_count = document_count - 1 WHERE id = NEW.collection_id;
+            END IF;
+        
+        -- handle un-archiving (increment)
+        ELSIF (OLD.is_archived = true AND NEW.is_archived = false AND NEW.collection_id IS NOT NULL) THEN
+             SELECT EXISTS (
+                SELECT 1 FROM public.documents 
+                WHERE collection_document_id = NEW.collection_document_id 
+                AND collection_id = NEW.collection_id
+                AND id != NEW.id 
+                AND is_archived = false
+            ) INTO has_revision;
+
+            IF NOT has_revision THEN
+                UPDATE public.collections SET document_count = document_count + 1 WHERE id = NEW.collection_id;
+            END IF;
+
+        -- handle potential move between collections (possible in sql but not UI)
+        ELSIF (OLD.collection_id IS DISTINCT FROM NEW.collection_id AND NEW.is_archived = false) THEN
+            IF (OLD.collection_id IS NOT NULL) THEN
+                UPDATE public.collections SET document_count = document_count - 1 WHERE id = OLD.collection_id;
+            END IF;
+            IF (NEW.collection_id IS NOT NULL) THEN
+                UPDATE public.collections SET document_count = document_count + 1 WHERE id = NEW.collection_id;
+            END IF;
+        END IF;
+
+    -- increment on create
+    ELSIF (TG_OP = 'INSERT' AND NEW.collection_id IS NOT NULL AND NEW.is_archived = false) THEN
+        -- check for other revisions first
+        SELECT EXISTS (
+            SELECT 1 FROM public.documents 
+            WHERE collection_document_id = NEW.collection_document_id 
+            AND collection_id = NEW.collection_id
+            AND id != NEW.id 
+            AND is_archived = false
+        ) INTO has_revision;
+
+        -- only increment if no other revisions, since a revision doesn't count as a new doc
+        IF NOT has_revision THEN
+            UPDATE public.collections SET document_count = document_count + 1 WHERE id = NEW.collection_id;
+        END IF;
+
+    -- decrement on actual sql DELETE (possible in sql but not UI)
+    ELSIF (TG_OP = 'DELETE' AND OLD.collection_id IS NOT NULL AND OLD.is_archived = false) THEN
+        SELECT EXISTS (
+            SELECT 1 FROM public.documents 
+            WHERE collection_document_id = OLD.collection_document_id 
+            AND collection_id = NEW.collection_id
+            AND id != OLD.id 
+            AND is_archived = false
+        ) INTO has_revision;
+
+        IF NOT has_revision THEN
+            UPDATE public.collections SET document_count = document_count - 1 WHERE id = OLD.collection_id;
+        END IF;
+    END IF;
+
+    RETURN NULL;
+END;
+$function$
+;
+
+CREATE TRIGGER on_document_updated_update_collection_count AFTER INSERT OR DELETE OR UPDATE ON public.documents FOR EACH ROW EXECUTE FUNCTION public.sync_collection_document_count();


### PR DESCRIPTION
### In this PR

Per https://github.com/recogito/recogito-client/issues/441:
- Add new `iiif_sync_status` table, and related RPC, to enable simplified task queue for processing large IIIF collections in chunks (it's similar to `jobs` in a way, but contains specialized columns for this workflow, and is accessible only by the service role—not user facing)
- Add a documents counter cache to `collections`, and a trigger to update it when documents change, to efficiently track the number of docs in each collection
- Make document retrieval, search, and sorting more efficient for very large collections
   - Add computed columns to `documents` based on collection metadata: document ID and revision number; and IIIF metadata: author/artist
   - Add a trigger function to populate the IIIF author metadata since it can't be extracted by a `GENERATED ALWAYS BY` statement
   - Add `pg_trgm` trigram search extension and indices to avoid massive overhead on `ILIKE` queries
   - Create a new RPC that combines `LIMIT` and `OFFSET`-based retrieval, search, and sort for the document library frontend, in order to enable infinite scroll in combination with those existing features (and ensuring only one document listed for all revisions of the same document)

### See also

- https://github.com/performant-software/recogito-cloud/pull/16
- https://github.com/performant-software/iiif-collection-csv/pull/3